### PR TITLE
Scope only exits on run intent

### DIFF
--- a/Interstation-Two-WW2/code/modules/WW2/weapons/zoom.dm
+++ b/Interstation-Two-WW2/code/modules/WW2/weapons/zoom.dm
@@ -218,7 +218,7 @@ Parts of code courtesy of Super3222
 	if(client && actions.len)
 		if(client.pixel_x || client.pixel_y) //Cancel currently scoped weapons
 			for(var/datum/action/toggle_scope/T in actions)
-				if(T.scope.zoomed)
+				if(T.scope.zoomed && src.m_intent=="run")
 					T.scope.zoom(src, FALSE)
 
 // called from Life()


### PR DESCRIPTION
Walkers can keep scope zoom