### PR TITLE
Players whose dream seeker window is minimized no longer count toward…

### DIFF
--- a/Interstation-Two-WW2/code/game/gamemodes/WW2/ww2.dm
+++ b/Interstation-Two-WW2/code/game/gamemodes/WW2/ww2.dm
@@ -83,7 +83,8 @@
 	var/only_client_is_host = FALSE
 	for(var/mob/new_player/player in player_list)
 		if(player.client)
-			++playercount
+			if (!player.client.is_minimized())
+				++playercount
 			if (player.key == world.host)
 				only_client_is_host = TRUE
 

--- a/Interstation-Two-WW2/code/modules/client/client_procs.dm
+++ b/Interstation-Two-WW2/code/modules/client/client_procs.dm
@@ -389,6 +389,10 @@
 	if(inactivity > duration)	return inactivity
 	return FALSE
 
+//Checks if the client game window is minimized
+/client/proc/is_minimized()
+	return winget(src, "mainwindow", "is-minimized")
+
 /client/proc/inactivity2text()
 	var/seconds = inactivity/10
 	return "[round(seconds / 60)] minute\s, [seconds % 60] second\s"


### PR DESCRIPTION
…s the minimum players required to start the round. is_minimized() added in client_procs