### PR TITLE
Unable to Move Glitch Fix

### DIFF
--- a/code/modules/WW2/jobs/german.dm
+++ b/code/modules/WW2/jobs/german.dm
@@ -343,7 +343,7 @@
 	H.setStat("smg", STAT_NORMAL)
 	H.setStat("pistol", STAT_NORMAL)
 	H.setStat("heavyweapon", STAT_MEDIUM_LOW)
-	H.setStat("medical", STAT_MEDIUM_HIGH)
+	H.setStat("medical", STAT_VERY_HIGH)
 	H.setStat("shotgun", STAT_NORMAL)
 	return TRUE
 
@@ -1200,7 +1200,7 @@ var/first_fallschirm = TRUE
 	H.setStat("smg", STAT_MEDIUM_HIGH)
 	H.setStat("pistol", STAT_VERY_HIGH)
 	H.setStat("heavyweapon", STAT_MEDIUM_HIGH)
-	H.setStat("medical", STAT_NORMAL)
+	H.setStat("medical", STAT_VERY_HIGH)
 	H.setStat("survival", STAT_VERY_HIGH)
 	H.setStat("shotgun", STAT_NORMAL)
 	H.setStat("stamina", STAT_VERY_HIGH)

--- a/code/modules/WW2/jobs/italian.dm
+++ b/code/modules/WW2/jobs/italian.dm
@@ -79,7 +79,7 @@
 	H.setStat("smg", STAT_NORMAL)
 	H.setStat("pistol", STAT_NORMAL)
 	H.setStat("heavyweapon", STAT_MEDIUM_LOW)
-	H.setStat("medical", STAT_MEDIUM_HIGH)
+	H.setStat("medical", STAT_VERY_HIGH)
 	H.setStat("shotgun", STAT_NORMAL)
 	return TRUE
 

--- a/code/modules/WW2/jobs/japanese.dm
+++ b/code/modules/WW2/jobs/japanese.dm
@@ -231,7 +231,7 @@
 	H.setStat("smg", STAT_NORMAL)
 	H.setStat("pistol", STAT_NORMAL)
 	H.setStat("heavyweapon", STAT_MEDIUM_LOW)
-	H.setStat("medical", STAT_MEDIUM_HIGH)
+	H.setStat("medical", STAT_VERY_HIGH)
 	H.setStat("shotgun", STAT_NORMAL)
 	return TRUE
 

--- a/code/modules/WW2/jobs/soviet.dm
+++ b/code/modules/WW2/jobs/soviet.dm
@@ -295,7 +295,7 @@
 	H.setStat("smg", STAT_NORMAL)
 	H.setStat("pistol", STAT_NORMAL)
 	H.setStat("heavyweapon", STAT_MEDIUM_LOW)
-	H.setStat("medical", STAT_MEDIUM_HIGH)
+	H.setStat("medical", STAT_VERY_HIGH)
 	H.setStat("shotgun", STAT_NORMAL)
 	return TRUE
 

--- a/code/modules/WW2/jobs/usa.dm
+++ b/code/modules/WW2/jobs/usa.dm
@@ -226,7 +226,7 @@
 	H.setStat("smg", STAT_NORMAL)
 	H.setStat("pistol", STAT_NORMAL)
 	H.setStat("heavyweapon", STAT_MEDIUM_LOW)
-	H.setStat("medical", STAT_MEDIUM_HIGH)
+	H.setStat("medical", STAT_VERY_HIGH)
 	H.setStat("shotgun", STAT_NORMAL)
 	return TRUE
 

--- a/code/modules/mob/grab.dm
+++ b/code/modules/mob/grab.dm
@@ -323,7 +323,7 @@
 /obj/item/weapon/grab/dropped()
 	if (ismob(loc))
 		var/mob/M = loc
-		M.grab_list -= src
+		M.grab_list -= null
 	loc = null
 	if (!destroying)
 		qdel(src)
@@ -343,7 +343,7 @@
 	if (loc)
 		if (ismob(loc))
 			var/mob/M = loc
-			M.grab_list -= src
+			M.grab_list -= null
 
 	animate(affecting, pixel_x = FALSE, pixel_y = FALSE, 4, TRUE, LINEAR_EASING)
 	affecting.layer = 4


### PR DESCRIPTION
Changes two things in Grab.dm code that fixes the current Unable to Move glitch that admins have to fix ingame.

I fixed this because I'm tired of getting those hecking ahelps.